### PR TITLE
[Dual-ToR] update sai.profile with SAI_ADDITIONAL_MAC_ENABLED attribute if corresponding arg passed to syncd

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -196,6 +196,9 @@ config_syncd_mlnx()
     # Read MAC address
     MAC_ADDRESS="$(echo $SYNCD_VARS | jq -r '.mac')"
 
+    # Check whether additional MAC feature enabled
+    ADDITIONAL_MAC="$(echo $SYNCD_VARS | jq -r '.additional_mac')"
+
     # Make default sai.profile
     if [[ -f $HWSKU_DIR/sai.profile.j2 ]]; then
         export RESOURCE_TYPE="$(echo $SYNCD_VARS | jq -r '.resource_type')"
@@ -207,6 +210,10 @@ config_syncd_mlnx()
     # Update sai.profile with MAC_ADDRESS and WARM_BOOT settings
     echo "DEVICE_MAC_ADDRESS=$MAC_ADDRESS" >> /tmp/sai.profile
     echo "SAI_WARM_BOOT_WRITE_FILE=/var/warmboot/" >> /tmp/sai.profile
+
+    if [[ "$ADDITIONAL_MAC" == "enable" ]]; then
+       echo "SAI_ADDITIONAL_MAC_ENABLED=1" >> /tmp/sai.profile
+    fi
 
     SDK_DUMP_PATH=`cat /tmp/sai.profile|grep "SAI_DUMP_STORE_PATH"|cut -d = -f2`
     if [ ! -d "$SDK_DUMP_PATH" ]; then


### PR DESCRIPTION
Signed-off-by: Andriy Yurkiv <ayurkiv@nvidia.com>

Update sai.profile with SAI_ADDITIONAL_MAC_ENABLED=1  if  "additional_mac" attr is passed to syncd 